### PR TITLE
Perf improvements

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,6 +9,7 @@ use clap::ArgMatches;
 use std::path::PathBuf;
 use protobuf::descriptor::FileDescriptorSet;
 use libc;
+use formatter::CustomFormatter;
 
 pub struct CommandRunner {
     descriptors: Vec<FileDescriptorSet>,
@@ -91,11 +92,13 @@ fn decode_or_convert<T: Iterator<Item = Vec<u8>>>(
             &msgtype
         );
 
+        let mut formatter = CustomFormatter::new(out_is_tty);
+
         for (ctr, item) in consumer.enumerate() {
             if count >= 0 && ctr >= count as usize {
                 return;
             }
-            decoder.decode_message(&item, &mut stdout.lock(), out_is_tty);
+            decoder.decode_message(&item, &mut stdout.lock(), &mut formatter);
         }
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,18 +1,20 @@
+use clap::ArgMatches;
+use libc;
+use protobuf::descriptor::FileDescriptorSet;
+use serde_value::Value;
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::mpsc::channel;
+use std::thread::spawn;
+
 use decode::PqDecoder;
 use discovery::get_loaded_descriptors;
-use serde_value::Value;
+use formatter::CustomFormatter;
 use stream_delimit::byte_consumer::ByteConsumer;
 use stream_delimit::stream::*;
 use stream_delimit::converter::Converter;
-use std::io::{self, Write};
-use clap::ArgMatches;
-use std::path::PathBuf;
-use protobuf::descriptor::FileDescriptorSet;
-use libc;
-use formatter::CustomFormatter;
 
-use std::sync::mpsc::channel;
-use std::thread::spawn;
 
 pub struct CommandRunner {
     descriptors: Vec<FileDescriptorSet>,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -82,11 +82,13 @@ fn decode_or_convert<T: Iterator<Item = Vec<u8>>>(
             stdout_.write_all(&item).expect("Couldn't write to stdout");
         }
     } else {
+        let msgtype = format!(".{}",
+                              matches
+                              .value_of("MSGTYPE")
+                              .expect("Must supply --msgtype or --convert"));
         let decoder = PqDecoder::new(
             descriptors,
-            matches
-                .value_of("MSGTYPE")
-                .expect("Must supply --msgtype or --convert"),
+            &msgtype
         );
 
         for (ctr, item) in consumer.enumerate() {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -26,20 +26,20 @@ impl<'a> PqDecoder<'a> {
         }
     }
 
-    pub fn decode_message(&self, data: &[u8], out: &mut Write, formatter: &mut CustomFormatter) {
+    pub fn decode_message(&self, data: &[u8]) -> Value {
         let stream = CodedInputStream::from_bytes(data);
-        let mut deserializer = Deserializer::for_named_message(
-            &self.descriptors,
-            self.message_type,
-            stream,
-        ).expect("Couldn't initialize deserializer");
+        let mut deserializer =
+            Deserializer::for_named_message(&self.descriptors, self.message_type, stream)
+            .expect("Couldn't initialize deserializer");
         match Value::deserialize(&mut deserializer) {
-            Ok(x) => {
-                if let Err(e) = x.serialize(&mut Serializer::with_formatter(out, formatter)) {
-                    panic!("Couldn't serialize message: {}", e);
-                }
-            }
+            Ok(x) => x,
             Err(e) => panic!("Couldn't decode message: {}", e),
+        }
+    }
+
+    pub fn write_message(&self, v: Value, out: &mut Write, formatter: &mut CustomFormatter) {
+        if let Err(e) = v.serialize(&mut Serializer::with_formatter(out, formatter)) {
+            panic!("Couldn't serialize message: {}", e);
         }
     }
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -30,7 +30,7 @@ impl<'a> PqDecoder<'a> {
         let stream = CodedInputStream::from_bytes(data);
         let mut deserializer = Deserializer::for_named_message(
             &self.descriptors,
-            &(format!(".{}", self.message_type)),
+            self.message_type,
             stream,
         ).expect("Couldn't initialize deserializer");
         match Value::deserialize(&mut deserializer) {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -26,7 +26,7 @@ impl<'a> PqDecoder<'a> {
         }
     }
 
-    pub fn decode_message(&self, data: &[u8], out: &mut Write, is_tty: bool) {
+    pub fn decode_message(&self, data: &[u8], out: &mut Write, formatter: &mut CustomFormatter) {
         let stream = CodedInputStream::from_bytes(data);
         let mut deserializer = Deserializer::for_named_message(
             &self.descriptors,
@@ -35,10 +35,7 @@ impl<'a> PqDecoder<'a> {
         ).expect("Couldn't initialize deserializer");
         match Value::deserialize(&mut deserializer) {
             Ok(x) => {
-                if let Err(e) = x.serialize(&mut Serializer::with_formatter(
-                    out,
-                    CustomFormatter::new(is_tty),
-                )) {
+                if let Err(e) = x.serialize(&mut Serializer::with_formatter(out, formatter)) {
                     panic!("Couldn't serialize message: {}", e);
                 }
             }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -22,7 +22,7 @@ impl CustomFormatter {
     }
 }
 
-impl Formatter for CustomFormatter {
+impl <'a> Formatter for &'a mut CustomFormatter {
     fn begin_array<W: ?Sized + Write>(&mut self, w: &mut W) -> io::Result<()> {
         self.formatter.begin_array(w)
     }

--- a/stream-delimit/src/byte_consumer.rs
+++ b/stream-delimit/src/byte_consumer.rs
@@ -5,24 +5,24 @@ use stream::*;
 use std::io::Read;
 
 /// A consumer for a byte stream
-pub struct ByteConsumer<'a> {
-    read: &'a mut Read,
+pub struct ByteConsumer<T: Read> {
+    read: T,
     type_: StreamType,
 }
 
-impl<'a> ByteConsumer<'a> {
+impl <T: Read> ByteConsumer<T> {
     /// Return a ByteConsumer from for single messages, varint or leb128-delimited
-    pub fn new(read: &'a mut Read, type_: StreamType) -> ByteConsumer {
+    pub fn new(read: T, type_: StreamType) -> ByteConsumer<T> {
         ByteConsumer { read, type_ }
     }
 }
 
-impl<'a> Iterator for ByteConsumer<'a> {
+impl <T: Read> Iterator for ByteConsumer<T> {
     type Item = Vec<u8>;
 
     fn next(&mut self) -> Option<Vec<u8>> {
         match self.type_ {
-            StreamType::Leb128 | StreamType::Varint => consume_single_varint(self.read),
+            StreamType::Leb128 | StreamType::Varint => consume_single_varint(&mut self.read),
             StreamType::Single => {
                 let ret: Option<Vec<u8>>;
                 let mut buf = Vec::new();


### PR DESCRIPTION
This PR improves the performance of pq.

- Two commits move some computations outside of loops.  Both commits affect the current API of pq.
- One commit introduces concurrency to pq.  One thread reads from the consumer and decodes the Protobuf; another thread encodes to JSON and writes to stdout.  The two threads communicate via an unbounded channel.  This also required changing the public API.

In the tests I've performed the performance increase varies between 50% and 100%.

```
~/src/pq$ ./pq-release [elided] < records.127MiB | pv -blat >/dev/null
 900k 0:00:21 [41.2k/s]

~/src/pq$ ./pq-threaded [elided] < records.127MiB | pv -blat >/dev/null
 900k 0:00:10 [85.9k/s]
```