### PR TITLE
Add Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ $ pq --msgtype com.example.dog.Dog --stream varint <./tests/samples/dog_stream
 }
 ```
 
+[More usage](./USAGE.md)
+
 ### Compiling for Windows
 
 1. Install [Visual Studio Installer](https://visualstudio.microsoft.com/downloads/) Community edition

--- a/README.md
+++ b/README.md
@@ -42,4 +42,13 @@ $ pq --msgtype com.example.dog.Dog --stream varint <./tests/samples/dog_stream
 }
 ```
 
-[More usage](./USAGE.md)
+### Compiling for Windows
+
+1. Install [Visual Studio Installer](https://visualstudio.microsoft.com/downloads/) Community edition
+2. Run the installer and install `Visual Studio Build Tools 2019`. You need the `C++ Build Tools` workload. Note that you can't just install the minimal package, you also need `MSVC C++ x64/86 Build Tools` and `Windows 10 SDK`.
+3. Open `x64 Native Tools Command Prompt` from the start menu.
+4. Download and run [`rustup-init.exe`](https://win.rustup.rs/x86_64)
+5. Close and reopen your terminal (so `cargo` will be in your path)
+6. Run `cargo install --no-default-features pq`
+
+Note that this will disable the Kafka feature. Kafka is not currently supported on Windows.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -49,7 +49,7 @@ impl CommandRunner {
     }
 
     pub fn run_byte(self, matches: &ArgMatches<'_>) {
-        if unsafe { libc::isatty(libc::STDIN_FILENO) != 0 } {
+        if unsafe { libc::isatty(0) != 0 } {
             panic!("pq expects input to be piped from stdin");
         }
         let stream_type = str_to_streamtype(matches.value_of("STREAM").unwrap_or("single"))
@@ -70,7 +70,7 @@ fn decode_or_convert<T: 'static + Send + Iterator<Item = Vec<u8>>>(
     let count = value_t!(matches, "COUNT", i32).unwrap_or(-1);
 
     let stdout = io::stdout();
-    let out_is_tty = unsafe { libc::isatty(libc::STDOUT_FILENO) != 0 };
+    let out_is_tty = unsafe { libc::isatty(1) != 0 };
 
     if let Some(convert_type) = matches.value_of("CONVERT") {
         let converter = Converter::new(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -45,7 +45,7 @@ impl CommandRunner {
 
     #[cfg(not(feature = "default"))]
     pub fn run_kafka(self, _: &ArgMatches) {
-        not_implemented!("This version of pq has been compiled without kafka support");
+        unimplemented!("This version of pq has been compiled without kafka support");
     }
 
     pub fn run_byte(self, matches: &ArgMatches<'_>) {


### PR DESCRIPTION
- Avoid dependence on POSIX APIs not supported by Windows
- Don't crash when compiling without Kafka
- Document Windows installation steps

Note this does not add support for Kafka because installing openssl on windows is a real headache.

Addresses https://github.com/sevagh/pq/issues/88