### PR TITLE
Increase max fetch per partition

### DIFF
--- a/stream-delimit/src/kafka_consumer.rs
+++ b/stream-delimit/src/kafka_consumer.rs
@@ -52,7 +52,10 @@ impl Iterator for KafkaConsumer {
                             break;
                         }
                     }
-                    Err(_) => return None,
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        return None;
+                    }
                 }
             }
         }
@@ -76,6 +79,7 @@ impl KafkaConsumer {
         )
         .with_topic(topic.to_owned())
         .with_fallback_offset(fetch_offset)
+        .with_fetch_max_bytes_per_partition(1 * 1024 * 1024)
         .create()
         {
             Ok(consumer) => Ok(KafkaConsumer {


### PR DESCRIPTION
Otherwise the stream will end immediately with a swallowed error on large message sets.
This solves the same issue #98 sough to solve, but in a much simpler fashion