### PR TITLE
Remove an S from the end of PROTOC_INCLUDES in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ pq --protofile ./tests/protos/dog.proto  --msgtype com.example.dog.Dog <./test
 }
 ```
 
-Use PROTOC and PROTOC_INCLUDES to control the executed protoc binary and configure the `-I=/proto/path` argument (design copied from [prost](https://github.com/danburkert/prost/blob/master/prost-build/src/lib.rs)).
+Use PROTOC and PROTOC_INCLUDE to control the executed protoc binary and configure the `-I=/proto/path` argument (design copied from [prost](https://github.com/danburkert/prost/blob/master/prost-build/src/lib.rs)).
 
 To set up, put your `*.fdset` files in `~/.pq`, `/etc/pq`, or a different directory specified with the `FDSET_PATH` env var:
 


### PR DESCRIPTION
Hi.

This PR makes the spelling of the documented env variable for the protoc include path match the spelling used in the code.

Sorry to bother you with such a small annoyance, but this briefly tripped me up when trying the --protofile feature.
